### PR TITLE
Revert "Remove tabs and clean up code from 4c622c504f8f7c479a8368f767…

### DIFF
--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -632,12 +632,17 @@ GCode::travel_to(const Point &point, ExtrusionRole role, std::string comment)
     
     // use G1 because we rely on paths being straight (G0 may make round paths)
     Lines lines = travel.lines();
-    for (Lines::const_iterator line = lines.begin(); line != lines.end(); ++line)
-        gcode += this->writer.travel_to_xy(this->point_to_gcode(line->b), comment);
-    
+    double path_length = 0;
+    for (Lines::const_iterator line = lines.begin(); line != lines.end(); ++line) {
+	    const double line_length = line->length() * SCALING_FACTOR;
+	    path_length += line_length;
+
+	    gcode += this->writer.travel_to_xy(this->point_to_gcode(line->b), comment);
+    }
+
     if (this->config.cooling)
-        this->elapsed_time += travel.length() / this->config.get_abs_value("travel_speed");
-    
+        this->elapsed_time += path_length / this->config.get_abs_value("travel_speed");
+
     return gcode;
 }
 


### PR DESCRIPTION
…2ec96426391554"

This reverts commit 3daf64ae56bd8f7cc0de84c70ae1bf1973afc79e.

It breaks auto-cooling.

Example:
10x10x50.stl (MD5: 87fb65b6d4835257d97adcd333b0ad8d)

solid OpenSCAD_Model
  facet normal 0 0 0
    outer loop
vertex 0 10 50
vertex 10 0 50
vertex 10 10 50
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 0 10 50
vertex 0 0 50
vertex 10 0 50
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 10 0 0
vertex 0 10 0
vertex 10 10 0
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 10 0 0
vertex 0 0 0
vertex 0 10 0
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 0 0 50
vertex 10 0 0
vertex 10 0 50
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 0 0 50
vertex 0 0 0
vertex 10 0 0
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 10 0 50
vertex 10 10 0
vertex 10 10 50
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 10 0 50
vertex 10 0 0
vertex 10 10 0
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 0 10 50
vertex 10 10 0
vertex 0 10 0
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 0 10 50
vertex 10 10 50
vertex 10 10 0
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 0 0 50
vertex 0 10 0
vertex 0 0 0
    endloop
  endfacet
  facet normal 0 0 0
    outer loop
vertex 0 0 50
vertex 0 10 50
vertex 0 10 0
    endloop
  endfacet
endsolid OpenSCAD_Model

slic3r.pl --cooling 10x10x50.stl ; grep "M106" 10x10x50.gcode

before revert:
shows nothing

after revert:
shows two lines

Signed-off-by: Christian Inci <chris.pcguy.inci@gmail.com>